### PR TITLE
fix: allow for option handlers to use `this`

### DIFF
--- a/packages/nest-commander/src/command-runner-core.service.ts
+++ b/packages/nest-commander/src/command-runner-core.service.ts
@@ -51,7 +51,7 @@ export class CommandRunnerCoreService implements OnModuleInit {
         newCommand.option(
           option.meta.flags,
           option.meta.description ?? '',
-          option.discoveredMethod.handler,
+          option.discoveredMethod.handler.bind(command.instance),
           option.meta.defaultValue ?? undefined,
         );
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
       '@nestjs/testing': 7.6.5_0c0a57cf47818081758771caab802b19
       commander: 6.2.1
       jest: 26.6.3
-      nest-commander: 'link:../packages/nest-commander'
-      nest-commander-testing: 'link:../packages/nest-commander-testing'
+      nest-commander: link:../packages/nest-commander
+      nest-commander-testing: link:../packages/nest-commander-testing
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.1.3
       typescript: 4.1.3
     specifiers:
@@ -61,8 +61,8 @@ importers:
       '@nestjs/testing': ^7.6.5
       commander: ^6.2.1
       jest: ^26.6.3
-      nest-commander: 'workspace:*'
-      nest-commander-testing: 'workspace:*'
+      nest-commander: workspace:*
+      nest-commander-testing: workspace:*
       ts-jest: ^26.4.4
       typescript: ^4.1.3
   packages/nest-commander:
@@ -96,7 +96,7 @@ importers:
       '@nestjs/core': 7.6.5_f545d9736447f44a5b3cb1701b885beb
       '@nestjs/testing': 7.6.5_0c0a57cf47818081758771caab802b19
       jest: 26.6.3
-      nest-commander: 'link:../nest-commander'
+      nest-commander: link:../nest-commander
       reflect-metadata: 0.1.13
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.1.3
       typescript: 4.1.3
@@ -106,7 +106,7 @@ importers:
       '@nestjs/core': ^7.6.5
       '@nestjs/testing': ^7.6.5
       jest: ^26.6.3
-      nest-commander: 'workspace:*'
+      nest-commander: workspace:*
       reflect-metadata: ^0.1.13
       ts-jest: ^26.4.4
       typescript: ^4.1.3
@@ -5724,7 +5724,7 @@ packages:
       request-promise-core: 1.1.4_request@2.88.2
       stealthy-require: 1.1.1
       tough-cookie: 2.5.0
-    deprecated: 'request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142'
+    deprecated: request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
     engines:
       node: '>=0.12.0'
     peerDependencies:
@@ -5753,7 +5753,7 @@ packages:
       tough-cookie: 2.5.0
       tunnel-agent: 0.6.0
       uuid: 3.4.0
-    deprecated: 'request has been deprecated, see https://github.com/request/request/issues/3142'
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
     engines:
       node: '>= 6'
     resolution:
@@ -5808,7 +5808,7 @@ packages:
     resolution:
       integrity: sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==
   /resolve-url/0.2.1:
-    deprecated: 'https://github.com/lydell/resolve-url#deprecated'
+    deprecated: https://github.com/lydell/resolve-url#deprecated
     resolution:
       integrity: sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
   /resolve/1.19.0:
@@ -6756,7 +6756,7 @@ packages:
     resolution:
       integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   /urix/0.1.0:
-    deprecated: 'Please see https://github.com/lydell/urix#deprecated'
+    deprecated: Please see https://github.com/lydell/urix#deprecated
     resolution:
       integrity: sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
   /use/3.1.1:


### PR DESCRIPTION
Parse handlers had to define all data inside the `parseHandler`
method because `this` was not being properly bound to the class.
`this` is not properly bound to the handler and it works as expected.